### PR TITLE
label below toggle switch

### DIFF
--- a/EuroPanelMaker/components/toggle.scad
+++ b/EuroPanelMaker/components/toggle.scad
@@ -17,4 +17,4 @@ module toggle_switch(){
 
 }
 
-pot_alpha_16mm();
+toggle_switch();

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -34,11 +34,11 @@ rectangular_holes = []; // [3, 100, x1, y1, x2, y2]
 
 label_font = "Liberation Sans:style=bold";
 label_font_size = 3;
-pot_label_distance = 10;
+pot_label_distance = 12;
 pot_label_font_size = 3;
-jack_label_distance = 6;
+jack_label_distance = 8;
 jack_label_font_size = 3;
-toggle_label_distance = 6;
+toggle_label_distance = 8;
 
 // Flip panel for 3D printing
 panel_flipped = false;
@@ -200,7 +200,8 @@ module generate_pots(params=[2, 95, "Label"]){
             text(params[2],
                  font=label_font,
                  size=pot_label_font_size,
-                 halign="center");
+                 halign="center",
+                 valign="center");
         }
     }
 }
@@ -219,14 +220,15 @@ module generate_jacks(params=[2, 95, "Label"]){
             text(params[2],
                  font=label_font,
                  size=jack_label_font_size,
-                 halign="center");
+                 halign="center",
+                 valign="center");
         }
     }
 }
 
-module generate_toggle_switch(params=[2, 95, "Label"]){
+module generate_toggle_switch(params=[2, 95, "Label", ""]){
     translate([eurorack_w * params[0], params[1], component_depth])
-        if (params[3]) {
+        if (params[4]) {
             rotate([0,0,params[3]]) #toggle_switch();
         } else {
             #toggle_switch();
@@ -238,7 +240,18 @@ module generate_toggle_switch(params=[2, 95, "Label"]){
             text(params[2],
                  font=label_font,
                  size=pot_label_font_size,
-                 halign="center");
+                 halign="center",
+                 valign="center");
+        }
+    }
+    
+    translate([eurorack_w * params[0], params[1]-toggle_label_distance, panel_thickness-text_depth ]) {
+        linear_extrude(height=text_depth+1) {
+            text(params[3],
+                 font=label_font,
+                 size=pot_label_font_size,
+                 halign="center",
+                 valign="center");
         }
     }
 }

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -39,6 +39,7 @@ pot_label_font_size = 3;
 jack_label_distance = 8;
 jack_label_font_size = 3;
 toggle_label_distance = 8;
+toggle_label_font_size = 3;
 
 // Flip panel for 3D printing
 panel_flipped = false;
@@ -239,7 +240,7 @@ module generate_toggle_switch(params=[2, 95, "Label", ""]){
         linear_extrude(height=text_depth+1) {
             text(params[2],
                  font=label_font,
-                 size=pot_label_font_size,
+                 size=toggle_label_font_size,
                  halign="center",
                  valign="center");
         }
@@ -249,7 +250,7 @@ module generate_toggle_switch(params=[2, 95, "Label", ""]){
         linear_extrude(height=text_depth+1) {
             text(params[3],
                  font=label_font,
-                 size=pot_label_font_size,
+                 size=toggle_label_font_size,
                  halign="center",
                  valign="center");
         }

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -38,7 +38,7 @@ pot_label_distance = 12;
 pot_label_font_size = 3;
 jack_label_distance = 8;
 jack_label_font_size = 3;
-toggle_label_distance = 8;
+toggle_label_distance = 12;
 toggle_label_font_size = 3;
 
 // Flip panel for 3D printing


### PR DESCRIPTION
This adds an additional parameter to toggle switches so a second label can be added below the switch (useful for switches that toggle between waveshapes for instance). It is an empty string by default, so if only a label above is desired, it can be omitted. If the switch is to be rotated, then the bottom label must be explicitly listed.

Additionally, to simplify adding labels below, each text element for a component has `valign="center"`, and default distances have been adjusted accordingly.

Note: there is currently no documentation regarding toggle switches. This should be addressed.