### PR TITLE
1/4 inch jack support

### DIFF
--- a/EuroPanelMaker/components/jack_14in.scad
+++ b/EuroPanelMaker/components/jack_14in.scad
@@ -1,0 +1,16 @@
+$fn = $preview ? 20 : 100; 
+tolerance = 0.3;
+
+module jack_14in() {
+    cylinder(r = 4.4 + tolerance, h = 7.5);
+    
+    translate([0, 0, -22.5]) 
+    union() {
+        cylinder(r = 9.5, h = 22.5);
+        
+        translate([-5.5, 8, 0])
+        cube([11, 2.3, 22.5]);
+    } 
+}
+
+jack_14in();

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -1,4 +1,5 @@
 use <components/jack_35mm.scad>
+use <components/jack_14in.scad>
 use <components/led.scad>
 use <components/pot_alpha_16mm.scad>
 use <components/mounting_tab.scad>
@@ -38,6 +39,8 @@ pot_label_distance = 12;
 pot_label_font_size = 3;
 jack_label_distance = 8;
 jack_label_font_size = 3;
+jack_14in_label_distance = 12;
+jack_14in_label_font_size = 3;
 switch_label_distance = 12;
 switch_label_font_size = 3;
 
@@ -211,13 +214,23 @@ module generate_pots(params=[2, 95, "Label"]) {
 }
 
 module generate_jacks(params=[2, 95, "Label"]){
-    translate([eurorack_w * params[0], params[1], component_depth])
-    rotate([0, 0, params[3] ? params[3] : 0])
-    #jack_35mm();
+    if (!params[3] || params[3] == "35mm") {
+        translate([eurorack_w * params[0], params[1], component_depth])
+        rotate([0, 0, params[4] ? params[4] : 0])
+        #jack_35mm();
 
-    translate([eurorack_w * params[0], params[1] + jack_label_distance, panel_thickness - text_depth])
-    linear_extrude(height = text_depth + 1)
-    text(params[2], font = label_font, size = jack_label_font_size, halign = "center", valign = "center");
+        translate([eurorack_w * params[0], params[1] + jack_label_distance, panel_thickness - text_depth])
+        linear_extrude(height = text_depth + 1)
+        text(params[2], font = label_font, size = jack_label_font_size, halign = "center", valign = "center");
+    } else if (params[3] == "14in") {
+        translate([eurorack_w * params[0], params[1], component_depth])
+        rotate([0, 0, params[4] ? params[4] : 0])
+        #jack_14in();
+
+        translate([eurorack_w * params[0], params[1] + jack_14in_label_distance, panel_thickness - text_depth])
+        linear_extrude(height = text_depth + 1)
+        text(params[2], font = label_font, size = jack_14in_label_font_size, halign = "center", valign = "center");
+    }
 }
 
 module generate_switches(params=[2, 95, "Label", ""]){

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -244,7 +244,7 @@ module generate_switches(params=[2, 95, "Label", ""]){
     
     translate([eurorack_w * params[0], params[1] - switch_label_distance, panel_thickness - text_depth])
     linear_extrude(height = text_depth + 1)
-    text(params[2], font = label_font, size = switch_label_font_size, halign = "center", valign = "center");
+    text(params[3], font = label_font, size = switch_label_font_size, halign = "center", valign = "center");
 }
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pots = [
 ];
 
 jacks = [
-    [x (in HP column), y (mm), label, rotation (degrees)]
+    [x (in HP column), y (mm), label, size, rotation (degrees)]
 ];
 
 switches = [
@@ -48,7 +48,11 @@ leds = [
     [x (in HP column), y (mm), diameter (mm)]
 ];
 ```
-Add as many components as necessary in each array. *Note: the rotation parameter can be omitted for no rotation.*
+Add as many components as necessary in each array. Some notes:
+
+- The rotation parameter on any component can be omitted for no rotation
+- The options for jack size is `"35mm"` (for 3.5mm) or `"14in"` (for 1/4 inch) - if omitted, then it will be 3.5mm
+- The label below parameter for a switch can be omitted for no label below the switch
 
 Finally, generate the panel.
 ```

--- a/template.scad
+++ b/template.scad
@@ -28,7 +28,7 @@ leds = [ // x (in HP column), y (mm), diameter (mm)
     [3, 35, 3]
 ];
 
-jacks = [ // x (in HP column), y (mm), label, rotation (degrees)
+jacks = [ // x (in HP column), y (mm), label, size, rotation (degrees)
     [1, 18, "In"] ,
     [3, 18, "Out"],
     [1, 35, "CV"]


### PR DESCRIPTION
This addresses #12 

If other types of potentiometers are added (such as desired in #4), a similar method can be used. That is, include a parameter prior to rotation that indicates type/size, and use if/else in the generate function.