### PR TITLE
Added support for hex spacers

### DIFF
--- a/EuroPanelMaker/components/spacer.scad
+++ b/EuroPanelMaker/components/spacer.scad
@@ -1,0 +1,27 @@
+// Hex Spacers
+
+tolerance = 0.3;
+$fn = $preview ? 20 : 100;
+
+module spacer(m=3) {
+    dims = [
+        [2, 3.3],
+        [2.5, 5.3],
+        [3, 5.3],
+        [4, 6.7],
+        [5, 8],
+        [6, 9]
+    ];
+
+    n = dims[search(m, dims)[0]][1];
+    
+    echo("N: ", n);
+    cylinder(r = m/2 + tolerance, h = 8);
+    
+    translate([0, 0, -10])
+    union() {        
+        cylinder(r = n/2 + tolerance, h = 10, $fn=6);
+    }
+}
+
+spacer();

--- a/EuroPanelMaker/components/spacer.scad
+++ b/EuroPanelMaker/components/spacer.scad
@@ -4,7 +4,7 @@ tolerance = 0.3;
 $fn = $preview ? 20 : 100;
 
 module spacer(m=3) {
-    dims = [
+    widths = [
         [2, 3.3],
         [2.5, 5.3],
         [3, 5.3],
@@ -13,14 +13,14 @@ module spacer(m=3) {
         [6, 9]
     ];
 
-    n = dims[search(m, dims)[0]][1];
+    w = widths[search(m, widths)[0]][1];
     
-    echo("N: ", n);
+    echo("W: ", w);
     cylinder(r = m/2 + tolerance, h = 8);
     
     translate([0, 0, -10])
     union() {        
-        cylinder(r = n/2 + tolerance, h = 10, $fn=6);
+        cylinder(r = w/2 + tolerance, h = 10, $fn=6);
     }
 }
 

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -5,6 +5,7 @@ use <components/pot_alpha_16mm.scad>
 use <components/mounting_tab.scad>
 use <components/switch.scad>
 use <components/key.scad>
+use <components/spacer.scad>
 
 eurorack_h = 128.5;
 eurorack_w = 5.08;
@@ -183,9 +184,29 @@ module generatePanel() {
                     generate_rectangular_holes(rectangular_holes_mm[idx], rectangular_holes_mm[idx][0]);
                 }
             }
+            
+            for (idx = [0 : len(spacers)]) {
+                if (spacers[idx]) {
+                    echo("SPACER:", idx = spacers[idx]);
+                    generate_spacers(spacers[idx], eurorack_w * spacers[idx][0]);
+                }
+            }
+            
+            for (idx = [0 : len(spacers_mm)]) {
+                if (spacers_mm[idx]) {
+                    echo("SPACER_MM:", idx = spacers_mm[idx]);
+                    generate_spacers(spacers_mm[idx], spacers_mm[idx][0]);
+                }
+            }
         }
     }
 
+}
+
+
+module generate_spacers(params = [3, 100, 3], xpos){
+    translate([xpos, params[1], 0 ])
+        spacer(m=params[2]);
 }
 
 module generate_rectangular_holes(params = [3, 100, 25, 20, 30, 30], xpos) {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ keys = [
 rectangular_holes = [
     [x, y, inner_width (mm), inner_height (mm), outer_width (mm), outer_height (mm)]
 ];
+
+spacers = [
+    [x, y, size (2, 2.5, 3, 4, 5, 6)]
+];
 ```
+
 Add as many components as necessary in each array. Some notes:
 
 - The rotation parameter on any component can be omitted for no rotation

--- a/tests/test-spacer.scad
+++ b/tests/test-spacer.scad
@@ -1,8 +1,8 @@
 include <../EuroPanelMaker/panel.scad>
 
 
-hp = 6;
-title = "SPACER";
+hp = 2;
+title = "S";
 margin = 0; // Add extra width on each side for support
 
 pots = []; // x (in HP column), y (mm), label, rotation (degrees)
@@ -11,11 +11,11 @@ jacks = []; // x (in HP column), y (mm), label, rotation (degrees)
 switches = [];
 
 spacers = [
-    [3, 100, 3]
+    [1, 100, 3]
 ];
 
 spacers_mm = [
-    [10, 80, 3]
+    [5, 80, 3]
 ];
 
 

--- a/tests/test-spacer.scad
+++ b/tests/test-spacer.scad
@@ -1,0 +1,23 @@
+include <../EuroPanelMaker/panel.scad>
+
+
+hp = 6;
+title = "SPACER";
+margin = 0; // Add extra width on each side for support
+
+pots = []; // x (in HP column), y (mm), label, rotation (degrees)
+leds = []; // x (in HP column), y (mm), diameter (mm)
+jacks = []; // x (in HP column), y (mm), label, rotation (degrees)
+switches = [];
+
+spacers = [
+    [3, 100, 3]
+];
+
+spacers_mm = [
+    [10, 80, 3]
+];
+
+
+panel_flipped = false;
+generatePanel();


### PR DESCRIPTION
Added support for hex spacers. Use:

```
spacers = [
    [x, y, size (2, 2.5, 3, 4, 5, 6)]
];
```

![IMG20230831102535](https://github.com/benjiaomodular/EuroPanelMaker/assets/5189714/af0673c5-222f-488e-8092-24539858713e)

![IMG20230831102528](https://github.com/benjiaomodular/EuroPanelMaker/assets/5189714/859818ee-70a9-4f1b-b743-c547c8db83f5)
