### PR TITLE
Added support for RD901F pots

### DIFF
--- a/EuroPanelMaker/components/pot_alpha_16mm.scad
+++ b/EuroPanelMaker/components/pot_alpha_16mm.scad
@@ -1,3 +1,5 @@
+// Based on Alpha RV16 dimensions
+
 tolerance = 0.3;
 $fn = $preview ? 20 : 100;
 

--- a/EuroPanelMaker/components/pot_rd901f.scad
+++ b/EuroPanelMaker/components/pot_rd901f.scad
@@ -1,0 +1,20 @@
+// Based on Alpha RD901F
+
+tolerance = 0.3;
+$fn = $preview ? 20 : 100;
+
+module pot_rd901f() {
+    translate([0, 0, -1])
+    cylinder(r = 3.5 + tolerance, h = 8);
+
+    translate([-1, -6.5, -1])
+    cube([2, 3, 1]);
+    
+    translate([0, 0, -11])
+        union() {
+            translate([-5, -6.5, 0])
+            cube([10, 12, 10]);
+        }
+}
+
+pot_rd901f();

--- a/EuroPanelMaker/components/pot_rv16.scad
+++ b/EuroPanelMaker/components/pot_rv16.scad
@@ -3,7 +3,7 @@
 tolerance = 0.3;
 $fn = $preview ? 20 : 100;
 
-module pot_alpha_16mm() {
+module pot_rv16() {
     cylinder(r = 3.5 + tolerance, h = 8);
     
     translate([0, 0, -0.5])

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -37,6 +37,7 @@ switches = [];
 labels = [];
 keys = [];
 rectangular_holes = []; // [3, 100, x1, y1, x2, y2]
+spacers = [];
 
 pots_rd901f_mm = [];
 pots_mm = [];
@@ -46,6 +47,7 @@ switches_mm = [];
 labels_mm = [];
 keys_mm = [];
 rectangular_holes_mm = []; // [3, 100, x1, y1, x2, y2]
+spacers_mm = [];
 
 label_font = "Liberation Sans:style=bold";
 label_font_size = 3;

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -1,7 +1,7 @@
 use <components/jack_35mm.scad>
 use <components/jack_14in.scad>
 use <components/led.scad>
-use <components/pot_alpha_16mm.scad>
+use <components/pot_rv16.scad>
 use <components/pot_rd901f.scad>
 use <components/mounting_tab.scad>
 use <components/switch.scad>
@@ -314,7 +314,7 @@ module generate_extra_labels(params, width) {
 module generate_pots(params, width) {
     translate([width, params[1], component_depth])
     rotate([0, 0, params[3] ? params[3] : 0])
-    #pot_alpha_16mm();
+    #pot_rv16();
 
     translate([width, params[1] + pot_label_distance, panel_thickness - text_depth])
     linear_extrude(height = text_depth + 1)

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -2,6 +2,7 @@ use <components/jack_35mm.scad>
 use <components/jack_14in.scad>
 use <components/led.scad>
 use <components/pot_alpha_16mm.scad>
+use <components/pot_rd901f.scad>
 use <components/mounting_tab.scad>
 use <components/switch.scad>
 use <components/key.scad>
@@ -29,6 +30,7 @@ title_y = 118;
 title_rotate = 0;
 
 pots = [];
+pots_rd901f = [];
 leds = [];
 jacks = [];
 switches = [];
@@ -36,6 +38,7 @@ labels = [];
 keys = [];
 rectangular_holes = []; // [3, 100, x1, y1, x2, y2]
 
+pots_rd901f_mm = [];
 pots_mm = [];
 leds_mm = [];
 jacks_mm = [];
@@ -101,6 +104,20 @@ module generatePanel() {
                 }
             }
             
+            for (idx = [0 : len(pots_rd901f)]) {
+                if (pots_rd901f[idx]) {
+                    echo("POTS RD901F:", idx = pots_rd901f[idx]);
+                    generate_pots_rd901f(pots_rd901f[idx], eurorack_w * pots_rd901f[idx][0]);
+                }
+            }
+            
+            for (idx = [0 : len(pots_rd901f_mm)]) {
+                if (pots_rd901f_mm[idx]) {
+                    echo("POTS RD901F:", idx = pots_rd901f_mm[idx]);
+                    generate_pots_rd901f(pots_rd901f_mm[idx], pots_rd901f_mm[idx][0]);
+                }
+            }
+                     
             for (idx = [0 : len(leds)]) {
                 if (leds[idx]) {
                     echo("LED:", idx = leds[idx]);
@@ -296,6 +313,16 @@ module generate_pots(params, width) {
     translate([width, params[1], component_depth])
     rotate([0, 0, params[3] ? params[3] : 0])
     #pot_alpha_16mm();
+
+    translate([width, params[1] + pot_label_distance, panel_thickness - text_depth])
+    linear_extrude(height = text_depth + 1)
+    text(params[2], font = label_font, size = pot_label_font_size, halign = "center", valign = "center");
+}
+
+module generate_pots_rd901f(params, width) {
+    translate([width, params[1], component_depth])
+    rotate([0, 0, params[3] ? params[3] : 0])
+    #pot_rd901f();
 
     translate([width, params[1] + pot_label_distance, panel_thickness - text_depth])
     linear_extrude(height = text_depth + 1)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ pots = [
     [x (in HP column), y (mm), label, rotation (degrees)]
 ];
 
+pots_rd901f = [
+    [x (in HP column), y (mm), label, rotation (degrees)]
+];
+
 jacks = [
     [x (in HP column), y (mm), label, size, rotation (degrees)]
 ];

--- a/tests/test-pots-rd901f.scad
+++ b/tests/test-pots-rd901f.scad
@@ -1,0 +1,21 @@
+include <../EuroPanelMaker/panel.scad>
+
+
+hp = 4;
+title = "901";
+margin = 0; // Add extra width on each side for support
+
+pots_rd901f = [
+    [2, 100, "0"],
+    [2, 80, "90", 90],
+    [2, 60, "180", 180],]; // x (in HP column), y (mm), label, rotation (degrees)
+
+pots_rd901f_mm = [
+    [10, 20, "mm"]];
+    
+leds = []; // x (in HP column), y (mm), diameter (mm)
+
+jacks = []; // x (in HP column), y (mm), label, rotation (degrees)
+
+panel_flipped = false;
+generatePanel();


### PR DESCRIPTION
```
pots_rd901f = [
    [x (in HP column), y (mm), label, rotation (degrees)]
];
```

![photo_2023-08-31_13-51-15](https://github.com/benjiaomodular/EuroPanelMaker/assets/5189714/89ebd087-d432-4d05-96e9-56c7e0d9ad4d)

![photo_2023-08-31_13-51-10](https://github.com/benjiaomodular/EuroPanelMaker/assets/5189714/68a7f369-b490-4fd1-b534-b2efc9e5a5b9)
