### PR TITLE
Added support for SR16 Rotary Switches

### DIFF
--- a/EuroPanelMaker/components/switch_sr16.scad
+++ b/EuroPanelMaker/components/switch_sr16.scad
@@ -1,0 +1,14 @@
+tolerance = 0.3;
+$fn = $preview ? 20 : 100;
+
+module switch_sr16() {
+    cylinder(r = 4.5 + tolerance, h = 8);
+    
+    translate([-1, -8.5, 0])
+    cube([2, 9, 1]);
+       
+    translate([0, 0, -10])
+    cylinder(r = 8 + tolerance, h = 10);
+}
+
+switch_sr16();

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -5,6 +5,7 @@ use <components/pot_rv16.scad>
 use <components/pot_rd901f.scad>
 use <components/mounting_tab.scad>
 use <components/switch.scad>
+use <components/switch_sr16.scad>
 use <components/key.scad>
 use <components/spacer.scad>
 
@@ -34,6 +35,7 @@ pots_rd901f = [];
 leds = [];
 jacks = [];
 switches = [];
+switches_sr16 = [];
 labels = [];
 keys = [];
 rectangular_holes = []; // [3, 100, x1, y1, x2, y2]
@@ -44,6 +46,7 @@ pots_mm = [];
 leds_mm = [];
 jacks_mm = [];
 switches_mm = [];
+switches_sr16_mm = [];
 labels_mm = [];
 keys_mm = [];
 rectangular_holes_mm = []; // [3, 100, x1, y1, x2, y2]
@@ -154,7 +157,21 @@ module generatePanel() {
                     generate_switches(switches[idx], eurorack_w * switches[idx][0]);
                 }
             }
-
+            
+            for (idx = [0 : len(switches_sr16)]) {
+                if (switches_sr16[idx]) {
+                    echo("SWITCH SR16:", idx = switches_sr16[idx]);
+                    generate_switches_sr16(switches_sr16[idx], eurorack_w * switches_sr16[idx][0]);
+                }
+            }            
+            
+            for (idx = [0 : len(switches_sr16_mm)]) {
+                if (switches_sr16_mm[idx]) {
+                    echo("SWITCH SR16 (mm):", idx = switches_sr16_mm[idx]);
+                    generate_switches_sr16(switches_sr16_mm[idx], switches_sr16_mm[idx][0]);
+                }
+            }
+            
             for (idx = [0 : len(switches_mm)]) {
                 if (switches_mm[idx]) {
                     echo("SWITCH:", idx = switches_mm[idx]);
@@ -363,6 +380,16 @@ module generate_switches(params, width){
     translate([width, params[1] - switch_label_distance, panel_thickness - text_depth])
     linear_extrude(height = text_depth + 1)
     text(params[3], font = label_font, size = switch_label_font_size, halign = "center", valign = "center");
+}
+
+module generate_switches_sr16(params, xpos) {
+    translate([xpos, params[1], component_depth - 1])
+    rotate([0, 0, params[3] ? params[3] : 0])
+    #switch_sr16();
+
+    translate([xpos, params[1] + pot_label_distance, panel_thickness - text_depth])
+    linear_extrude(height = text_depth + 1)
+    text(params[2], font = label_font, size = pot_label_font_size, halign = "center", valign = "center");
 }
 
 module generate_keys(params, width){

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EuroPanelMaker
 
-![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker?sort=date)
+![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker?sort=date) ![GitHub Releases](https://img.shields.io/discord/1085224368126312468)
+
 
 Eurorack panel generator for OpenSCAD by [@benjiaomodular](https://www.instagram.com/benjiaomodular/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # EuroPanelMaker
+
+![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker)
+
 Eurorack panel generator for OpenSCAD by [@benjiaomodular](https://www.instagram.com/benjiaomodular/).
 
 ![Template preview](preview.png)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # EuroPanelMaker
 
-![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker?sort=date) ![GitHub Releases](https://img.shields.io/discord/1085224368126312468)
+![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker?sort=date) ![Discord](https://img.shields.io/discord/1085224368126312468?link=https%3A%2F%2Fdiscord.gg%2F4ze9BMehXX)
+
+Community
+
+    GitHub
+
+Open Collective
+Discord
+Twitter
+Awesome Badges
+Stats
+
+    Service Status
+
+Metrics dashboard
+Copyright © 2023 Shields.io. Built with Docusaurus.)
 
 
 Eurorack panel generator for OpenSCAD by [@benjiaomodular](https://www.instagram.com/benjiaomodular/).

--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ jacks = [
     [x (in HP column), y (mm), label, size, rotation (degrees)]
 ];
 
+// MTS-102
 switches = [
     [x (in HP column), y (mm), label above, label below, rotation (degrees)]
+];
+
+switches_sr16 = [
+    [x (in HP column), y (mm), label, rotation (degrees)]
 ];
 
 leds = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EuroPanelMaker
 
-![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker)
+![GitHub Releases](https://img.shields.io/github/release/benjiaomodular/EuroPanelMaker?sort=date)
 
 Eurorack panel generator for OpenSCAD by [@benjiaomodular](https://www.instagram.com/benjiaomodular/).
 

--- a/tests/test-switch-sr16.scad
+++ b/tests/test-switch-sr16.scad
@@ -1,0 +1,20 @@
+include <../EuroPanelMaker/panel.scad>
+
+
+hp = 4;
+title = "SR16";
+margin = 0; // Add extra width on each side for support
+
+pots = []; // x (in HP column), y (mm), label, rotation (degrees)
+leds = []; // x (in HP column), y (mm), diameter (mm)
+jacks = []; // x (in HP column), y (mm), label, rotation (degrees)
+switches_sr16 = [
+    [2, 100, "0"],
+    [2, 70, "90", 90],
+];
+
+switches_sr16_mm = [
+    [10, 40, "mm", 180],
+];
+
+generatePanel();


### PR DESCRIPTION
The switches have anti-rotation lugs that have to be filed down about halfway in order to fit properly. 

![photo_2023-08-31_15-33-09](https://github.com/benjiaomodular/EuroPanelMaker/assets/5189714/c563b62a-8bd5-4573-a2c5-762b42f145f6)
