### PR TITLE
Correct mounting holes for 2hp modules

### DIFF
--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -320,26 +320,26 @@ module generate_title() {
 }
 
 module generate_mounting_holes(params=[2, 95, "Label"]) {
-    if (hp == 1) {
-        translate([eurorack_w/2, 3, 0])
+    if (hp == 1){
+        translate([c, 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
         
-        translate([eurorack_w/2, eurorack_h - 3, 0])
+        translate([c, eurorack_h - 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
-    } else if(hp == 2){
+    } else if (hp == 2){
         hull(){
             translate([eurorack_w/2, 3, 0])
             cylinder(r = 1.6, h = 10, center = true);
-
-            translate([eurorack_w/2+3, 3, 0])
+            
+            translate([eurorack_w/2 + 3, 3, 0])
             cylinder(r = 1.6, h = 10, center = true);
         }
-
+        
         hull(){
-            translate([eurorack_w/2, eurorack_h-3, 0])
+            translate([eurorack_w/2, eurorack_h - 3, 0])
             cylinder(r = 1.6, h = 10, center = true);
-
-            translate([eurorack_w/2+3, eurorack_h-3, 0])
+            
+            translate([eurorack_w/2 + 3, eurorack_h - 3, 0])
             cylinder(r = 1.6, h = 10, center = true);
         }
     } else {

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -320,12 +320,28 @@ module generate_title() {
 }
 
 module generate_mounting_holes(params=[2, 95, "Label"]) {
-    if (hp == 1 || hp == 2){
+    if (hp == 1) {
         translate([eurorack_w/2, 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
         
         translate([eurorack_w/2, eurorack_h - 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
+    } else if(hp == 2){
+        hull(){
+            translate([eurorack_w/2, 3, 0])
+            cylinder(r = 1.6, h = 10, center = true);
+
+            translate([eurorack_w/2+3, 3, 0])
+            cylinder(r = 1.6, h = 10, center = true);
+        }
+
+        hull(){
+            translate([eurorack_w/2, eurorack_h-3, 0])
+            cylinder(r = 1.6, h = 10, center = true);
+
+            translate([eurorack_w/2+3, eurorack_h-3, 0])
+            cylinder(r = 1.6, h = 10, center = true);
+        }
     } else {
         hull(){
             translate([6, 3, 0])

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -320,28 +320,12 @@ module generate_title() {
 }
 
 module generate_mounting_holes(params=[2, 95, "Label"]) {
-    if (hp == 1){
-        translate([c, 3, 0])
+    if (hp == 1 || hp == 2){
+        translate([eurorack_w/2, 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
         
-        translate([c, eurorack_h - 3, 0])
+        translate([eurorack_w/2, eurorack_h - 3, 0])
         cylinder(r = 1.6, h = 10, center = true);
-    } else if (hp == 2){
-        hull(){
-            translate([c - 1, 3, 0])
-            cylinder(r = 1.6, h = 10, center = true);
-            
-            translate([c + 1, 3, 0])
-            cylinder(r = 1.6, h = 10, center = true);
-        }
-        
-        hull(){
-            translate([c - 1, eurorack_h - 3, 0])
-            cylinder(r = 1.6, h = 10, center = true);
-            
-            translate([c + 1, eurorack_h - 3, 0])
-            cylinder(r = 1.6, h = 10, center = true);
-        }
     } else {
         hull(){
             translate([6, 3, 0])


### PR DESCRIPTION
The current formula for mounting holes for 2 HP is to create a centered slot. This is problematic since it doesn't really align with the way screw holes are positioned in threaded strips, i.e. 2.54, 7.62, 12.7, ... (2.54 + i*5.08). There is simply no hole that aligns with a slot at 1 HP i.e. 5.08. Most 2 HP modules out there put a round hole at either 2.54 or at 7.62 from the left edge of the module (e.g. https://www.doepfer.de/a180.htm, https://www.befaco.org/mudi/, www.instruomodular.com/product/1f/). This PR puts it at 2.54.