### PR TITLE
Increase internal height clearance for rails (rib_margin)

### DIFF
--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -36,7 +36,7 @@ panel_thickness = 2; // thickness
 component_depth = 1;
 text_depth = 1.4;
 
-rib_margin = 8;
+rib_margin = 8.5;
 rib_thickness = 3;
     
 hp = 6;


### PR DESCRIPTION
With the current value of rib_margin, 8 mm, the distance from the screw center to the thick part of the panel is 5 mm. This leaves an unnecessarily small clearance of 0 mm for e.g. the rails used by Doepfer, where the distance from the center of the screw to the inner edge is 5 mm.

Increasing rib_margin to 8.5mm gives enough clearance to allow for less than ideal situations.