### PR TITLE
Introduce key-value parameter system and add some params

### DIFF
--- a/EuroPanelMaker/components/led.scad
+++ b/EuroPanelMaker/components/led.scad
@@ -1,11 +1,14 @@
 tolerance = 0.3;
 $fn = $preview ? 20 : 100;
 
-module led(d = 3) {
-    cylinder(d = d + (2 * tolerance), h = 2.5);
-    
+module led(d = 3, flange_d = undef) {
+    flange_d = flange_d ? flange_d : d + 0.7;
+    // main led part, without flange
+    cylinder(d = d + (2 * tolerance), h = d*1.5);
+
+    // flange and hole
     translate([0, 0, -4])
-    cylinder(d = d + 1 + (2 * tolerance), h = 4);
+    cylinder(d = flange_d + (2 * tolerance), h = 4);
 }
 
 led();

--- a/EuroPanelMaker/components/switch.scad
+++ b/EuroPanelMaker/components/switch.scad
@@ -1,11 +1,13 @@
 tolerance = 0.3;
 $fn = $preview ? 20 : 100;
 
-module switch(){
-    cylinder(r = 3.5 + tolerance, h = 8);
+module switch(width=undef, diameter=undef){
+    width = width ? width : 8;
+    r = diameter ? diameter/2 : 3.5;
+    cylinder(r = r + tolerance, h = 8);
     
     translate([0, 0, -7.5])
-    cube([8 + tolerance * 2, 13 + tolerance * 2, 15], center = true);
+    cube([width + tolerance * 2, 13 + tolerance * 2, 15], center = true);
 }
 
 switch();

--- a/EuroPanelMaker/panel.scad
+++ b/EuroPanelMaker/panel.scad
@@ -379,6 +379,9 @@ module generate_mounting_holes(params=[2, 95, "Label"]) {
     } 
 }
 
+function alist_get(alist, key, default) = (!alist  || search([key], alist) == [[]]) ? default :
+    alist[search([key],alist)[0]][1];
+
 module generate_extra_labels(params, width) {
     translate([width, params[1], panel_thickness - text_depth ])
     rotate([0, 0, params[3] ? params[3] : 0])
@@ -407,6 +410,8 @@ module generate_pots_rd901f(params, width) {
 }
 
 module generate_jacks(params, width){
+    component_depth = alist_get(params[5], "component_depth", component_depth);
+
     if (!params[3] || params[3] == "35mm") {
         translate([width, params[1], component_depth])
         rotate([0, 0, params[4] ? params[4] : 0])
@@ -437,9 +442,13 @@ module generate_jacks(params, width){
 }
 
 module generate_switches(params, width){
+    component_depth = alist_get(params[5], "component_depth", component_depth);
+    switch_size = alist_get(params[5], "size", undef);
+    diameter = alist_get(params[5], "diameter", undef);
+
     translate([width, params[1], component_depth])
     rotate([0, 0, params[4] ? params[4] : 0])
-    #switch();
+    #switch(switch_size, diameter);
 
     translate([width, params[1] + switch_label_distance, panel_thickness - text_depth])
     linear_extrude(height = text_depth + 1)
@@ -469,10 +478,14 @@ module generate_keys(params, width){
     text(params[2], font = label_font, size = key_label_font_size, halign = "center", valign = "center");
 }
 
-
 module generate_leds(params, width){
+    component_depth = alist_get(params[3], "component_depth", component_depth);
+    flange_diam = alist_get(params[3], "flange_diam", undef);
+    diam = params[2];
+
     translate([width, params[1], component_depth])
-    #led(d = params[2]);
+    #led(diam, flange_diam);
+
 }
 
 // uncomment the following line for testing, otherwise it causes panels to generate twice


### PR DESCRIPTION
I've been working on a different system of passing parameters to components, in the form of a dict/alist/key-value mapping where optional parameters can be passed by name, e.g.:

```
switches = [
    [4,76, "hp", "lp", 0, [["size", 8.1],["diameter", 5.9-0.3]]],
];

leds = [
    [2, 40, 3, [["flange_diam", 3.8], ["component_depth", -1]],
];
```

Unfortunately, no proper dict/map syntax exists in scad, but I think the above works reasonably.

I think this is a more scalable approach; more parameters can easily be added without affecting existing ones. It is also easier on the memory, one doesn't have to remember which position in the list is for what parameter. Finally, one can pass optional values of any parameter without having to add dummy values for preceding parameters.

In this PR, I add the getter function which gets a value by name, and add some new parameters to led() and switch() as an example. I also add `"component_depth"` as a parameter for most components so the depth of each component can be specified individually.

Do you like this direction? If so, one needs to decide if any of the existing parameters should be turned into named parameters, and if any more parameters can be added.