### PR TITLE
Increase diameter of collar/flange hole for RV16

### DIFF
--- a/EuroPanelMaker/components/pot_rv16.scad
+++ b/EuroPanelMaker/components/pot_rv16.scad
@@ -7,7 +7,7 @@ module pot_rv16() {
     cylinder(r = 3.5 + tolerance, h = 8);
     
     translate([0, 0, -0.5])
-    cylinder(r = 5.4 + tolerance, h = 0.5);
+    cylinder(r = 5.9 + tolerance, h = 0.5);
        
     translate([0, 0, -10.5])
     union() {


### PR DESCRIPTION
For my pots, the small cylindrical recess for the disc-like "collar"/"flange" is slightly too narrow. If we can increase the diameter slightly light this, I think most pots will sit better.